### PR TITLE
BGDIINF_SB-1434: Don't crash when some log extra are not json serializable

### DIFF
--- a/logging_utilities/formatters/json_formatter.py
+++ b/logging_utilities/formatters/json_formatter.py
@@ -205,7 +205,13 @@ class JsonFormatter(logging.Formatter):
         if record.stack_info:
             message['stack_info'] = self.formatStack(record.stack_info)
 
-        return json.dumps(message, **self.kwargs)
+        # When adding all extras, to avoid crash when a log message adds an extra with a non
+        # serializable object, we add a default serializer.
+        default = self.kwargs.pop('default', None)
+        if self.add_always_extra and default is None:
+            default = str
+
+        return json.dumps(message, default=default, **self.kwargs)
 
 
 def basic_config(**kwargs):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -263,3 +263,28 @@ class BasicJsonFormatterTest(unittest.TestCase):
                 ("message", "Composed message leave empty"),
             ])
         )
+
+    def test_non_serializable_extra(self):
+
+        class TestObject:
+
+            def __str__(self):
+                return 'Test Object'
+
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(logger, add_always_extra=True)
+            logger.info(
+                'Composed message %s',
+                'with non serializable extra',
+                extra=dictionary([('test-object', TestObject())])
+            )
+        self.assertDictEqual(
+            json.loads(ctx.output[0], object_pairs_hook=dictionary),
+            dictionary([
+                ("levelname", "INFO"),
+                ('name', 'test_formatter'),
+                ("message", "Composed message with non serializable extra"),
+                ('test-object', 'Test Object'),
+            ])
+        )


### PR DESCRIPTION
In the JSON Formatter when trying to add record extra, that are not serializable object, to the JSON output, the formatter raised an Exception:

`TypeError: Object of type <object type> is not JSON serializable`

This was particularly an issue when using the formatter with `add_always_extra` option. In this case you don't have control of log message set by third party libraries which might add logs with non serializable extra. This is the case for example with `Django`.

Now by default when `add_always_extra` is set, the JSON formatter use the `str()` function for non serializable objects. This behavior can still be overriden using the `json.dumps()` `default` keyword argument, for example if you want to use `repr()` instead of `str()` do as follow:

`JsonFormatter(default=repr, add_always_extra=True)`