### PR TITLE
BGDIINF_SB-1434: Added ExtraFormatter

### DIFF
--- a/logging_utilities/formatters/extra_formatter.py
+++ b/logging_utilities/formatters/extra_formatter.py
@@ -1,0 +1,83 @@
+import logging
+import logging.config
+import re
+import sys
+from pprint import pformat
+
+from logging_utilities.formatters import RECORD_DFT_ATTR
+
+if sys.version_info < (3, 2):
+    raise ImportError('Only python 3.2 and above are supported')
+
+# parse the format to retrieve all key e.g. "%(message)s %(module)s" => ['message', 'module']
+KEYS_PATTERN = r'%\((\w+)\)[#0\- \+]?(?:\d+|\*)?(?:\.\d+|\.\*)?\d*[diouxXeEfFgGcrsa]'
+
+
+class ExtraFormatter(logging.Formatter):
+    """Logging Extra Formatter
+
+    This formatter enhance the python standard formatter to allow working with the log `extra`.
+    The python standard formatter will raise a ValueError() when adding extra keyword in the format
+    when this keyword is then missing from log record. This means that if you want to display a log
+    extra, you have to make sure that every log message contains this extra.
+
+    This formatter allow you to provide an `extra_fmt` parameter that will add record extra to the
+    log message when available. You can either add the entire extra dictionary: `extra_fmt='%s'` or
+    only some extras: `extra_fmt='%(extra1)s:%(extra2)s'`. In the latest case, when a key is missing
+    in extra, the value is replaced by `extra_default`.
+    When using the whole `extra` dictionary, you can use `extra_pretty_print` to improve the
+    formatting, note that in this case the log might be on multiline (this use pprint.pformat).
+    """
+
+    def __init__(
+        self,
+        fmt=None,
+        datefmt=None,
+        style='%',
+        validate=True,
+        extra_fmt=None,
+        extra_default='',
+        extra_pretty_print=False
+    ):
+        '''
+        Initialize the formatter with specified format strings.
+
+        Initialize the formatter either with the specified format string, or a default as described
+        in logging.Formatter.
+
+        Args:
+            extra_fmt: string
+                String format (old percent style only) for log extras. This can be used for instance
+                to automatically add all extras, e.g: `extra_fmt='extras=%s'` or to add only some
+                extra: `extra_fmt='%(extra1)s:%(extra2)s'`
+            extra_default: any
+                Default value to use for missing extra in record
+            extra_pretty_print: boolean
+                Set to true to use pprint.pformat on the extra dictionary
+        '''
+        super().__init__(fmt=fmt, datefmt=datefmt, style=style)
+        self.extra_fmt = extra_fmt
+        self._extras_keys = re.findall(KEYS_PATTERN, self.extra_fmt if self.extra_fmt else '')
+        self._default = extra_default
+        self._extra_pretty_print = extra_pretty_print
+
+    def formatMessage(self, record):
+        message = self._style.format(record)
+        if self.extra_fmt:
+            extra_keys = set(record.__dict__.keys()) - RECORD_DFT_ATTR
+            extras = {key: getattr(record, key) for key in extra_keys}
+            if extras:
+                missing_keys = set(self._extras_keys) - set(extras.keys())
+                extras.update({key: self._default for key in missing_keys})
+                if self._extra_pretty_print:
+                    try:
+                        message = '%s%s' % (message, self.extra_fmt % pformat(extras))
+                    except TypeError as err:
+                        if err.args[0] == 'format requires a mapping':
+                            raise ValueError(
+                                'Cannot use extra_pretty_print with named placeholder'
+                            ) from err
+                        raise err
+                else:
+                    message = '%s%s' % (message, self.extra_fmt % extras)
+        return message

--- a/tests/test_extra_formatter.py
+++ b/tests/test_extra_formatter.py
@@ -1,0 +1,170 @@
+import logging
+from collections import OrderedDict
+import unittest
+
+from logging_utilities.formatters.extra_formatter import ExtraFormatter
+
+
+class ExtraFormatterTest(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def _configure_logger(
+        cls, logger, fmt=None, extra_fmt=None, extra_default='', extra_pretty_print=False
+    ):
+        logger.setLevel(logging.DEBUG)
+
+        for handler in logger.handlers:
+            formatter = ExtraFormatter(
+                fmt,
+                extra_default=extra_default,
+                extra_fmt=extra_fmt,
+                extra_pretty_print=extra_pretty_print
+            )
+            handler.setFormatter(formatter)
+
+    def test_missing_extra(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(logger, fmt="%(message)s", extra_fmt=':%(extra1)s')
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            logger.info('Simple message with extra', extra={'extra1': 23})
+            logger.info('Composed message %s', 'with extra', extra={'extra1': 23})
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')
+        self.assertEqual(ctx.output[2], 'Simple message with extra:23')
+        self.assertEqual(ctx.output[3], 'Composed message with extra:23')
+
+    def test_missing_extra_default_none(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger, fmt="%(message)s", extra_fmt=':%(extra1)s:%(extra2)s', extra_default=None
+            )
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            logger.info('Simple message with extra', extra={'extra1': 23})
+            logger.info('Composed message %s', 'with extra', extra={'extra1': 23})
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')
+        self.assertEqual(ctx.output[2], 'Simple message with extra:23:None')
+        self.assertEqual(ctx.output[3], 'Composed message with extra:23:None')
+
+    def test_extra_format_as_dict(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(logger, fmt="%(message)s", extra_fmt=':extra=%s')
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            logger.info('Simple message with extra', extra={'extra2': 1})
+            logger.info('Composed message %s', 'with extra', extra={'extra2': 1})
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')
+        self.assertEqual(ctx.output[2], 'Simple message with extra:extra={\'extra2\': 1}')
+        self.assertEqual(ctx.output[3], 'Composed message with extra:extra={\'extra2\': 1}')
+
+    def test_extra_format_as_dict_pretty_print(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger, fmt="%(message)s", extra_fmt=':extra=%s', extra_pretty_print=True
+            )
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            logger.info('Simple message with extra', extra={'extra2': 1})
+            logger.info('Composed message %s', 'with extra', extra={'extra2': 1})
+            logger.info(
+                'Big extra using pretty print',
+                extra=OrderedDict([
+                    ('extra1', list(map(lambda i: 'test ' * i, range(5)))),
+                    ('extra2', {
+                        'extra2.1': list(map(lambda i: 'test ' * i, range(5)))
+                    }),
+                ])
+            )
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')
+        self.assertEqual(ctx.output[2], 'Simple message with extra:extra={\'extra2\': 1}')
+        self.assertEqual(ctx.output[3], 'Composed message with extra:extra={\'extra2\': 1}')
+        self.assertEqual(
+            ctx.output[4],
+            """Big extra using pretty print:extra={'extra1': ['',
+            'test ',
+            'test test ',
+            'test test test ',
+            'test test test test '],
+ 'extra2': {'extra2.1': ['',
+                         'test ',
+                         'test test ',
+                         'test test test ',
+                         'test test test test ']}}"""
+        )
+
+    def test_extra_format_custom(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger, fmt="%(message)s", extra_fmt=':extra2=%(extra2)s:extra3=%(extra3)s'
+            )
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            logger.info('Simple message with extra', extra={'extra1': 23, 'extra2': 1})
+            logger.info(
+                'Composed message %s',
+                'with extra',
+                extra={
+                    'extra1': 23, 'extra2': 1, 'extra3': 'test'
+                }
+            )
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')
+        self.assertEqual(ctx.output[2], 'Simple message with extra:extra2=1:extra3=')
+        self.assertEqual(ctx.output[3], 'Composed message with extra:extra2=1:extra3=test')
+
+    def test_extra_format_custom_default_none(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger,
+                fmt="%(message)s",
+                extra_fmt=':extra2=%(extra2)s:extra3=%(extra3)s',
+                extra_default=None
+            )
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            logger.info('Simple message with extra', extra={'extra1': 23, 'extra2': 1})
+            logger.info(
+                'Composed message %s',
+                'with extra',
+                extra={
+                    'extra1': 23, 'extra2': 1, 'extra3': 'test'
+                }
+            )
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')
+        self.assertEqual(ctx.output[2], 'Simple message with extra:extra2=1:extra3=None')
+        self.assertEqual(ctx.output[3], 'Composed message with extra:extra2=1:extra3=test')
+
+    def test_extra_format_custom_pretty_print(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger,
+                fmt="%(message)s",
+                extra_fmt=':extra2=%(extra2)s:extra3=%(extra3)s',
+                extra_pretty_print=True
+            )
+            logger.info('Simple message')
+            logger.info('Composed message: %s', 'this is a composed message')
+            with self.assertRaises(ValueError):
+                logger.info('Simple message with extra', extra={'extra1': 23, 'extra2': 1})
+                logger.info(
+                    'Composed message %s',
+                    'with extra',
+                    extra={
+                        'extra1': 23, 'extra2': 1, 'extra3': 'test'
+                    }
+                )
+        self.assertEqual(ctx.output[0], 'Simple message')
+        self.assertEqual(ctx.output[1], 'Composed message: this is a composed message')

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -113,7 +113,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     "system",
                     dictionary([(
                         "context",
-                        dictionary([("module", "test_formatter"), ("file", "test_formatter.py")])
+                        dictionary([("module", "test_json_formatter"),
+                                    ("file", "test_json_formatter.py")])
                     )])
                 ),
             ])
@@ -127,7 +128,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     "system",
                     dictionary([(
                         "context",
-                        dictionary([("module", "test_formatter"), ("file", "test_formatter.py")])
+                        dictionary([("module", "test_json_formatter"),
+                                    ("file", "test_json_formatter.py")])
                     )])
                 ),
             ])
@@ -141,7 +143,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     "system",
                     dictionary([(
                         "context",
-                        dictionary([("module", "test_formatter"), ("file", "test_formatter.py")])
+                        dictionary([("module", "test_json_formatter"),
+                                    ("file", "test_json_formatter.py")])
                     )])
                 ),
             ])
@@ -173,9 +176,9 @@ class BasicJsonFormatterTest(unittest.TestCase):
                 ("name", "test_formatter"),
                 ("message", "Composed message with list"),
                 ('list', [{
-                    "file": "test_formatter.py"
+                    "file": "test_json_formatter.py"
                 }, {
-                    "module": "test_formatter"
+                    "module": "test_json_formatter"
                 }]),
             ])
         )


### PR DESCRIPTION
This formatter allows to works with log extra as in JSONFormatter and use a normal text output as in logging.Formatter.

This is quite useful when you want to work with two handler using one with the JSONFormatter and the other one with logging.Formatter for standard text formatting output. Instead of using logging.Formatter you can use this new ExtraFormatter that allow you to also format the log extra even if not all logs add extras.

NOTE: the docu is not yet done, I would like to first have a first opinion on the functionality and configuration before doing the docu.