### PR TITLE
BGDIINF_SB-1681: Fixed django filter stringify request that are already JSON compatible

### DIFF
--- a/logging_utilities/filters/django_request.py
+++ b/logging_utilities/filters/django_request.py
@@ -62,11 +62,12 @@ class JsonDjangoRequest(logging.Filter):
                 # HttpRequest has a special headers property that is cached and is not always in
                 # record.request.__dict__
                 request['headers'] = self._jsonify_dict('request.headers', record.request.headers)
-        else:
+            setattr(record, 'request', request)
+        elif not isinstance(record.request, (str, int, float, list, dict)):
             # Django sets also in some log message extra={'request': socket.socket()} in this case
             # we simply stringify it
             request = str(record.request)
-        setattr(record, 'request', request)
+            setattr(record, 'request', request)
 
     def _jsonify_dict(self, prefix, dct):
         json_obj = dictionary()

--- a/tests/test_django_attribute.py
+++ b/tests/test_django_attribute.py
@@ -155,3 +155,21 @@ class RecordDjangoAttributesTest(unittest.TestCase):
                         )]),
             msg="Second message differ"
         )
+
+    def test_django_request_jsonify_other(self):
+        requests = ({'a': 1}, OrderedDict([('a', 1)]), ['a'], 45, 45.5, 'a')
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            test_logger = logging.getLogger('test_formatter')
+            self._configure_django_filter(
+                test_logger,
+                include_keys=[
+                    'request.META.REQUEST_METHOD', 'request.META.SERVER_NAME', 'request.environ'
+                ],
+                exclude_keys=['request.META.SERVER_NAME', 'request.environ.wsgi']
+            )
+            for request in requests:
+                test_logger.info('Simple message', extra={'request': request})
+
+        for i, request in enumerate(requests):
+            message = json.loads(ctx.output[i], object_pairs_hook=dictionary)
+            self.assertEqual(request, message['request'])


### PR DESCRIPTION
When the record.request is already a valid JSON type (str, int, float,
list or dict) the filter did changed it into a string.