### PR TITLE
BGDIINF_SB-1721: Fixed flask attribute filter crash

### DIFF
--- a/logging_utilities/__init__.py
+++ b/logging_utilities/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 2, 1)
+VERSION = (1, 2, 2)
 if isinstance(VERSION[-1], str):
     # Support for alpha version: 0.1.0-alpha1
     __version__ = "-".join([".".join(map(str, VERSION[:-1])), VERSION[-1]])

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,10 @@ def get_version(version_line):
 setup(
     name='logging-utilities',
     version=get_version(VERSION_LINE),
-    description=('A collection of useful logging formatters and filters. '
-                 'JSON Formatter, Extra Formatter, ISO Time Filter, Flask Filter, Django Filter, ...'),
+    description=(
+        'A collection of useful logging formatters and filters. '
+        'JSON Formatter, Extra Formatter, ISO Time Filter, Flask Filter, Django Filter, ...'
+    ),
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     platforms=["all"],


### PR DESCRIPTION
When the flask request contained a malformed json data and the json was
part of the filter configuration, the filter crashed with a
HTTPException which coudl have broken the flask application. For example
if the Flask application simply ignored the payload (e.g. for GET
request) but configured to log the json payload when available.