### PR TITLE
Bug-flask-query_string

### DIFF
--- a/logging_utilities/__init__.py
+++ b/logging_utilities/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 2, 2)
+VERSION = (1, 2, 3)
 if isinstance(VERSION[-1], str):
     # Support for alpha version: 0.1.0-alpha1
     __version__ = "-".join([".".join(map(str, VERSION[:-1])), VERSION[-1]])

--- a/logging_utilities/filters/flask_attribute.py
+++ b/logging_utilities/filters/flask_attribute.py
@@ -41,6 +41,8 @@ class FlaskRequestAttribute(logging.Filter):
                         value = ''
             if value is None or isinstance(value, (str, int, float, dict)):
                 setattr(record, rec_attribute, value)
+            elif isinstance(value, bytes):
+                setattr(record, rec_attribute, value.decode('utf-8'))
             elif attribute == 'headers':
                 setattr(record, rec_attribute, dict(value.items()))
             else:

--- a/tests/test_record_attribute.py
+++ b/tests/test_record_attribute.py
@@ -1,6 +1,7 @@
 import logging
 import unittest
 from logging import Formatter
+from urllib.parse import quote
 
 from flask import Flask
 
@@ -11,6 +12,10 @@ app = Flask(__name__)
 
 
 class RecordAttributesTest(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
 
     @classmethod
     def _configure_const_attribute(cls, logger):
@@ -26,10 +31,14 @@ class RecordAttributesTest(unittest.TestCase):
         logger.setLevel(logging.DEBUG)
 
         for handler in logger.handlers:
-            const_attribute = FlaskRequestAttribute(attributes=['url', 'method', 'headers', 'json'])
+            const_attribute = FlaskRequestAttribute(
+                attributes=['url', 'method', 'headers', 'json', 'query_string']
+            )
             handler.addFilter(const_attribute)
             handler.setFormatter(
-                Formatter("%(levelname)s:%(message)s:%(flask_request_url)s:%(flask_request_json)s")
+                Formatter(
+                    "%(levelname)s:%(message)s:%(flask_request_url)s:%(flask_request_json)s:%(flask_request_query_string)s"
+                )
             )
 
     def test_const_attribute(self):
@@ -58,9 +67,9 @@ class RecordAttributesTest(unittest.TestCase):
         self.assertEqual(
             ctx.output,
             [
-                'INFO:Simple message::',
-                'INFO:Composed message: this is a composed message::',
-                'INFO:Composed message with extra::'
+                'INFO:Simple message:::',
+                'INFO:Composed message: this is a composed message:::',
+                'INFO:Composed message with extra:::'
             ]
         )
 
@@ -97,12 +106,40 @@ class RecordAttributesTest(unittest.TestCase):
             ctx.output,
             [
                 # pylint: disable=line-too-long
-                'INFO:Simple message:http://localhost/make_report/2017:None',
-                'INFO:Composed message: this is a composed message:http://localhost/make_report/2017:None',
-                'INFO:Composed message with extra:http://localhost/make_report/2017:None',
-                'INFO:Simple message:http://localhost/make_report/2017:None',
-                "INFO:Simple message:http://localhost/make_report/2017:b'non json data'",
-                'INFO:Simple message:http://localhost/make_report/2017:{}',
-                "INFO:Simple message:http://localhost/make_report/2017:{'jsonData': 'this is a json data'}",
+                'INFO:Simple message:http://localhost/make_report/2017:None:',
+                'INFO:Composed message: this is a composed message:http://localhost/make_report/2017:None:',
+                'INFO:Composed message with extra:http://localhost/make_report/2017:None:',
+                'INFO:Simple message:http://localhost/make_report/2017:None:',
+                "INFO:Simple message:http://localhost/make_report/2017:b'non json data':",
+                'INFO:Simple message:http://localhost/make_report/2017:{}:',
+                "INFO:Simple message:http://localhost/make_report/2017:{'jsonData': 'this is a json data'}:",
+            ]
+        )
+
+    def test_flask_attribute_query_string(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_flask_attribute(logger)
+
+            with app.test_request_context('/make_report/2017?param1=value1'):
+                logger.info('Simple message')
+                logger.info('Composed message: %s', 'this is a composed message')
+                logger.info('Composed message %s', 'with extra', extra={'extra1': 23})
+
+            with app.test_request_context('/make_report/2017?param1=value1&param2=value2'):
+                logger.info('Simple message')
+
+            with app.test_request_context(f'/make_report/2017?param1={quote("This a string ?")}'):
+                logger.info('Simple message')
+
+        self.assertEqual(
+            ctx.output,
+            [
+                # pylint: disable=line-too-long
+                'INFO:Simple message:http://localhost/make_report/2017?param1=value1:None:param1=value1',
+                'INFO:Composed message: this is a composed message:http://localhost/make_report/2017?param1=value1:None:param1=value1',
+                'INFO:Composed message with extra:http://localhost/make_report/2017?param1=value1:None:param1=value1',
+                'INFO:Simple message:http://localhost/make_report/2017?param1=value1&param2=value2:None:param1=value1&param2=value2',
+                'INFO:Simple message:http://localhost/make_report/2017?param1=This%20a%20string%20%3F:None:param1=This%20a%20string%20%3F',
             ]
         )


### PR DESCRIPTION
The Flask request.query_string is a byte and not a string and was
therefore not added to the record when configured.