### PR TITLE
Fixed publish target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ package: $(PREP_PACKAGING_TIMESTAMP)
 
 
 .PHONY: publish
-publish: publish-check clean test package
+publish: clean test package publish-check
 	@echo "Tag and upload package version=$(PACKAGE_VERSION)"
 	@# Check if we use interactive credentials or not
 	@if [ -n "$(PYPI_PASSWORD)" ]; then \


### PR DESCRIPTION
We could not publish because the publish-check was done before package.
The package target update the version used in publish-check (in logging_utilities.egg-info/PKG-INFO file), therefore
it is important that package runs before