### PR TITLE
BGDIINF_SB-2520: JSON formatter trailing dot workaround

### DIFF
--- a/logging_utilities/__init__.py
+++ b/logging_utilities/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (2, 0, 0)
+VERSION = (2, 1, 0)
 if isinstance(VERSION[-1], str):
     # Support for alpha version: 0.1.0-alpha1
     __version__ = "-".join([".".join(map(str, VERSION[:-1])), VERSION[-1]])  # pragma: no cover

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,40 @@
+import unittest
+
+from nose2.tools import params
+
+from logging_utilities.formatters.json_formatter import dotted_key_regex
+
+
+class RegexTests(unittest.TestCase):
+
+    @params(
+        'my.key',
+        'my.key2',
+        'my.',
+        'k1.k3.',
+        'k_1.',
+        'k_.sk_2',
+        '_my.key',
+        '_1.',
+        '_1._1',
+        '_1a._2b._3b',
+        'a.b.c.',
+        'a1a.b2b.c2c.',
+        'a1a_.b2_b.c_2c.'
+    )
+    def test_json_formatter_dotted_key_regex_match(self, key):
+        self.assertIsNotNone(dotted_key_regex.match(key))
+
+    @params(
+        'my key.',
+        '1.2',
+        'This is a text. It contains dot.',
+        'my.key ',
+        ' my.key',
+        'my.key-test',
+        '1',
+        '1.test',
+        '_1.1test'
+    )
+    def test_json_formatter_dotted_key_regex_no_match(self, key):
+        self.assertIsNone(dotted_key_regex.match(key))


### PR DESCRIPTION
On the JSON Formatter if a key attribute is missing in the LogRecord it is
treated as a string constant. This is because we cannot differentiate in the
configuration between constant and missing attribute. A workaround for this
is to use the dot key notation with a trailing dot.