### PR TITLE
BGDIINF_SB-2520: Removed string constant from JSON Formatter - New Features - #breaking-changes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -495,7 +495,7 @@ preferred-modules=
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
@@ -510,7 +510,7 @@ max-locals=15
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=22
 
 # Maximum number of return / yield for function / method body.
 max-returns=6

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ package: $(PREP_PACKAGING_TIMESTAMP)
 
 
 .PHONY: publish
-publish: clean test package publish-check
+publish: clean_venv clean test package publish-check
 	@echo "Tag and upload package version=$(PACKAGE_VERSION)"
 	@# Check if we use interactive credentials or not
 	@if [ -n "$(PYPI_PASSWORD)" ]; then \
@@ -127,6 +127,7 @@ publish: clean test package publish-check
 
 .PHONY: clean_venv
 clean_venv:
+	if [ -e $(VENV)/bin/deactivate ]; then $(VENV)/deactivate; fi
 	rm -rf $(VENV)
 
 

--- a/logging_utilities/__init__.py
+++ b/logging_utilities/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (2, 1, 0)
+VERSION = (3, 0, 0)
 if isinstance(VERSION[-1], str):
     # Support for alpha version: 0.1.0-alpha1
     __version__ = "-".join([".".join(map(str, VERSION[:-1])), VERSION[-1]])  # pragma: no cover

--- a/logging_utilities/filters/django_request.py
+++ b/logging_utilities/filters/django_request.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest
 
 # From python3.7, dict is ordered. Ordered dict are preferred in order to keep the json output
 # in the same order as its definition
-if sys.version_info >= (3, 7):
+if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
     dictionary = dict
 else:
     dictionary = OrderedDict
@@ -71,7 +71,7 @@ class JsonDjangoRequest(logging.Filter):
 
     def _jsonify_dict(self, prefix, dct):
         json_obj = dictionary()
-        if sys.version_info < (3, 7):
+        if sys.version_info.major < 3 and sys.version_info.minor < 7:
             dct = OrderedDict(sorted(dct.items(), key=lambda t: t[0]))
         for key, value in dct.items():
             dotted_key = '{}.{}'.format(prefix, key)

--- a/logging_utilities/formatters/json_formatter.py
+++ b/logging_utilities/formatters/json_formatter.py
@@ -23,7 +23,7 @@ if sys.version_info < (3, 0):
 if sys.version_info >= (3, 7):
     dictionary = dict
 else:
-    dictionary = OrderedDict
+    dictionary = OrderedDict  # pragma: no cover
 
 DEFAULT_FORMAT = dictionary([('levelname', 'levelname'), ('name', 'name'), ('message', 'message')])
 _ENHANCED_STYLES = _STYLES.copy()
@@ -144,15 +144,13 @@ class JsonFormatter(logging.Formatter):
             return json.loads(fmt, object_pairs_hook=dictionary)
         if isinstance(fmt, (dictionary, OrderedDict)):
             return fmt
-        if isinstance(fmt, dict):
+        if isinstance(fmt, dict):  # pragma no cover
             warnings.warn(
                 "Current python version is lower than 3.7.0, the key's order of dict may be "
                 "different than the definition, please use `OrderedDict` instead.",
                 UserWarning
             )
             return dictionary((k, fmt[k]) for k in sorted(fmt.keys()))
-        if fmt is None:
-            return DEFAULT_FORMAT
 
         raise TypeError(
             '`{}` type is not supported, `fmt` must be json `str`, `OrderedDict` or `dict` type.'.
@@ -176,7 +174,7 @@ class JsonFormatter(logging.Formatter):
         extras = {key: record.__dict__[key] for key in record.__dict__ if is_extra_attribute(key)}
         if sys.version_info >= (3, 7):
             return extras
-        return dictionary((key, extras[key]) for key in sorted(extras.keys()))
+        return dictionary((key, extras[key]) for key in sorted(extras.keys()))  # pragma no cover
 
     def _add_list_to_message(self, record, lst, message):
         for value in lst:
@@ -205,6 +203,10 @@ class JsonFormatter(logging.Formatter):
                     pass
                 else:
                     message.append(intermediate_msg)
+            else:
+                raise ValueError(
+                    'Invalid value type={} for value={} in fmt'.format(type(value), value)
+                )  # pragma no cover
 
     def _add_object_to_message(self, record, obj, message):
         for key, value in obj.items():
@@ -231,6 +233,10 @@ class JsonFormatter(logging.Formatter):
                 message[key] = self._get_string_key_value(record, value)
                 if self.remove_empty and not message[key]:
                     del message[key]
+            else:
+                raise ValueError(
+                    'Invalid value type={} for value={} in fmt'.format(type(value), value)
+                )  # pragma no cover
 
     @classmethod
     def _get_dotted_key_value(cls, record, str_value):
@@ -239,7 +245,7 @@ class JsonFormatter(logging.Formatter):
         def get_dotted_key(dct, dotted_key):
             if not isinstance(dct, (dict)):
                 raise ValueError(
-                    f'Cannot get dotted key "{dotted_key}" from "{dct}": '
+                    'Cannot get dotted key "{}" from "{}": '.format(dotted_key, dct) +
                     'is not a record or dictionary'
                 )  # pragma: no cover
             key = dotted_key

--- a/tests/test_django_attribute.py
+++ b/tests/test_django_attribute.py
@@ -11,7 +11,7 @@ from logging_utilities.filters.django_request import JsonDjangoRequest
 from logging_utilities.formatters.json_formatter import JsonFormatter
 
 # From python3.7, dict is ordered
-if sys.version_info >= (3, 7):
+if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
     dictionary = dict
 else:
     dictionary = OrderedDict

--- a/tests/test_flask_attribute.py
+++ b/tests/test_flask_attribute.py
@@ -112,7 +112,9 @@ class FlaskAttributeTest(unittest.TestCase):
             with app.test_request_context('/make_report/2017?param1=value1&param2=value2'):
                 logger.info('Simple message')
 
-            with app.test_request_context(f'/make_report/2017?param1={quote("This a string ?")}'):
+            with app.test_request_context(
+                '/make_report/2017?param1={}'.format(quote("This a string ?"))
+            ):
                 logger.info('Simple message')
 
         self.assertEqual(

--- a/tests/test_flask_json_formatter.py
+++ b/tests/test_flask_json_formatter.py
@@ -10,7 +10,7 @@ from logging_utilities.filters.flask_attribute import FlaskRequestAttribute
 from logging_utilities.formatters.json_formatter import JsonFormatter
 
 # From python3.7, dict is ordered
-if sys.version_info >= (3, 7):
+if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
     dictionary = dict
 else:
     dictionary = OrderedDict

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -62,6 +62,20 @@ class BasicJsonFormatterTest(unittest.TestCase):
             )
             handler.setFormatter(formatter)
 
+    def test_string_fmt_param(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(logger, '{"level": "levelname", "message": "message"}')
+            logger.info('Simple message')
+
+        message = json.loads(ctx.output[0], object_pairs_hook=dictionary)
+        self.assertDictEqual(
+            message, dictionary([
+                ("level", "INFO"),
+                ("message", "Simple message"),
+            ])
+        )
+
     def test_simple_log(self):
         with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
             logger = logging.getLogger('test_formatter')
@@ -96,6 +110,22 @@ class BasicJsonFormatterTest(unittest.TestCase):
                 ("message", "Composed message with extra"),
             ])
         )
+
+    @params('non.existing', '%(non_existing)s', '%(non.existing)s', '%(non.existing)s with text')
+    def test_missing_attribute_raise(self, attribute):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger,
+                dictionary([
+                    ('level', 'levelname'),
+                    ('non-existing', attribute),
+                    ('message', 'message'),
+                ]),
+            )
+            with self.assertRaises(ValueError):
+                logger.info('Simple message')
+        self.assertListEqual(ctx.output, [])
 
     @params(
         (
@@ -339,6 +369,28 @@ class BasicJsonFormatterTest(unittest.TestCase):
             ])
         )
 
+    def test_stack_info(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger,
+                fmt=dictionary([
+                    ('levelname', 'levelname'),
+                    ('name', 'name'),
+                    ('message', 'message'),
+                ])
+            )
+            logger.info('Message with stack info', stack_info=True)
+        message = json.loads(ctx.output[0], object_pairs_hook=dictionary)
+        self.assertListEqual(list(message.keys()), ['levelname', 'name', 'message', 'stack_info'])
+        self.assertEqual(message['levelname'], 'INFO')
+        self.assertEqual(message['name'], 'test_formatter')
+        self.assertEqual(message['message'], 'Message with stack info')
+        self.assertTrue(
+            message['stack_info'].startswith('Stack (most recent call last):\n'),
+            msg='stack_info do not start with "Stack (most recent call last):\\n"'
+        )
+
     def test_exception(self):
         with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
             logger = logging.getLogger('test_formatter')
@@ -400,10 +452,17 @@ class BasicJsonFormatterTest(unittest.TestCase):
             logger = logging.getLogger('test_formatter')
             self._configure_logger(
                 logger,
-                fmt=dictionary([("level", "levelname"), ("message", "message"),
-                                ("non-existing-attribute", "%(nonExistingAttribute)s"),
-                                ("another-non-existing-attribute", "non_existing.dotted.attribute"),
-                                ("non-existing-attribute-as-constant", 'constant_value')]),
+                fmt=dictionary([
+                    ("level", "levelname"),
+                    ("message", "message"),
+                    ("non-existing-attribute", "%(nonExistingAttribute)s"),
+                    ("2nd-non-existing-attribute", "non_existing.dotted.attribute"),
+                    ("3rd-non-existing-attribute", 'some_var'),
+                    (
+                        "3rd-non-existing-attribute",
+                        'Some random text, 1.2 float. Should not be added.'
+                    ),
+                ]),
                 remove_empty=True,
                 ignore_missing=True
             )
@@ -411,8 +470,7 @@ class BasicJsonFormatterTest(unittest.TestCase):
         self.assertDictEqual(
             json.loads(ctx.output[0], object_pairs_hook=dictionary),
             dictionary([("level", "INFO"),
-                        ("message", "Composed message remove non existing attribute"),
-                        ("non-existing-attribute-as-constant", "constant_value")])
+                        ("message", "Composed message remove non existing attribute")])
         )
 
     def test_ignore_trailing_dot_in_key(self):
@@ -447,6 +505,38 @@ class BasicJsonFormatterTest(unittest.TestCase):
             dictionary([("level", "INFO"),
                         ("message", "Composed message existing dotted key as dict"),
                         ("trailing-dotted-key", dictionary([("a", 12), ("b", "this is b")]))])
+        )
+
+    def test_ignore_double_trailing_dot_in_key(self):
+        with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
+            logger = logging.getLogger('test_formatter')
+            self._configure_logger(
+                logger,
+                fmt=dictionary([
+                    ("level", "levelname"),
+                    ("message", "message"),
+                    ("trailing-dotted-key", "dotted_key.."),
+                ]),
+                remove_empty=False,
+                ignore_missing=True
+            )
+            logger.info('Composed message %s', 'remove non existing dotted key')
+            logger.info(
+                'Composed message %s',
+                'existing dotted key as dict',
+                extra={"dotted_key": ['a', 'b']}
+            )
+        self.assertDictEqual(
+            json.loads(ctx.output[0], object_pairs_hook=dictionary),
+            dictionary([("level", "INFO"),
+                        ("message", "Composed message remove non existing dotted key"),
+                        ("trailing-dotted-key", [])])
+        )
+        self.assertDictEqual(
+            json.loads(ctx.output[1], object_pairs_hook=dictionary),
+            dictionary([("level", "INFO"),
+                        ("message", "Composed message existing dotted key as dict"),
+                        ("trailing-dotted-key", ['a', 'b'])])
         )
 
     def test_leave_empty(self):
@@ -498,7 +588,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     ('level', 'levelname'),
                     ('request', dictionary([('path', 'request.path')])),
                     ('message', 'message'),
-                ])
+                ]),
+                ignore_missing=True
             )
             logger.info(
                 'Composed message %s',
@@ -534,7 +625,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     ('level', 'levelname'),
                     ('request', ['request.path', 'request.method']),
                     ('message', 'message'),
-                ])
+                ]),
+                ignore_missing=True
             )
             logger.info(
                 'Composed message %s',
@@ -571,7 +663,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     ('request', dictionary([('path', 'request.path')])),
                     ('message', 'message'),
                 ]),
-                remove_empty=True
+                remove_empty=True,
+                ignore_missing=True
             )
             logger.info(
                 'Composed message %s',
@@ -607,7 +700,8 @@ class BasicJsonFormatterTest(unittest.TestCase):
                     ('request', ['request.path', 'request.method']),
                     ('message', 'message'),
                 ]),
-                remove_empty=True
+                remove_empty=True,
+                ignore_missing=True
             )
             logger.info(
                 'Composed message %s',
@@ -633,18 +727,20 @@ class BasicJsonFormatterTest(unittest.TestCase):
             ])
         )
 
-    def test_constant(self):
+    def test_missing_attribute(self):
         with self.assertLogs('test_formatter', level=logging.DEBUG) as ctx:
             logger = logging.getLogger('test_formatter')
             self._configure_logger(
                 logger,
                 fmt=dictionary([
                     ('level', 'levelname'),
-                    ('1-constant', 'this is a constant'),
-                    ('2-constant', 'my_constant'),
-                    ('3-constant', 'This is a constant with dot.'),
-                    ('4-constant', 'my.constant%()s'),
-                    ('5-constant', 'my.constant.%()s'),
+                    ('1-missing-attr', 'this is a constant'),
+                    ('2-missing-attr', 'my_constant'),
+                    ('3-missing-attr', 'This is a constant with dot.'),
+                    ('4-missing-attr', 'my.constant%()s'),
+                    ('5-missing-attr', 'my.constant.%()s'),
+                    ('6-missing-attr', '%(This is a constant with dot.)s'),
+                    ('7-missing-attr', '%(test.a.)s'),
                     ('my-extra', 'my_extra'),
                     ('message', 'message'),
                 ]),
@@ -661,11 +757,13 @@ class BasicJsonFormatterTest(unittest.TestCase):
             json.loads(ctx.output[0], object_pairs_hook=dictionary),
             dictionary([
                 ("level", "INFO"),
-                ('1-constant', 'this is a constant'),
-                ('2-constant', 'my_constant'),
-                ('3-constant', 'This is a constant with dot.'),
-                ('4-constant', 'my.constant'),
-                ('5-constant', 'my.constant.'),
+                ('1-missing-attr', ''),
+                ('2-missing-attr', ''),
+                ('3-missing-attr', {}),
+                ('4-missing-attr', ''),
+                ('5-missing-attr', ''),
+                ('6-missing-attr', ''),
+                ('7-missing-attr', ''),
                 ("my-extra", "this is an extra"),
                 ("message", "Composed message with extra and constants"),
             ])
@@ -674,12 +772,14 @@ class BasicJsonFormatterTest(unittest.TestCase):
             json.loads(ctx.output[1], object_pairs_hook=dictionary),
             dictionary([
                 ("level", "INFO"),
-                ('1-constant', 'this is a constant'),
-                ('2-constant', 'my_constant'),
-                ('3-constant', 'This is a constant with dot.'),
-                ('4-constant', 'my.constant'),
-                ('5-constant', 'my.constant.'),
-                ("my-extra", "my_extra"),
+                ('1-missing-attr', ''),
+                ('2-missing-attr', ''),
+                ('3-missing-attr', {}),
+                ('4-missing-attr', ''),
+                ('5-missing-attr', ''),
+                ('6-missing-attr', ''),
+                ('7-missing-attr', ''),
+                ("my-extra", ""),
                 ("message", "Composed message without extra"),
             ])
         )

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -2,10 +2,22 @@ import unittest
 
 from nose2.tools import params
 
-from logging_utilities.formatters.json_formatter import dotted_key_regex
+from logging_utilities.formatters.json_formatter import EnhancedPercentStyle
 
 
 class RegexTests(unittest.TestCase):
+
+    @params(
+        '%(asctime)s',
+        '%(my.dotted.key)s',
+        '%(my.dotted.key)s with constant',
+        'leading constant %(my.dotted.key)s with constant',
+        'constant%(my.dotted.key)sconstant',
+        '%(my.dotted.key)d',
+        '%(my.dotted.key)3.4d',
+    )
+    def test_json_formatter_enhanced_percent_style_regex_match(self, value):
+        self.assertIsNotNone(EnhancedPercentStyle.validation_pattern.search(value))
 
     @params(
         'my.key',
@@ -20,12 +32,7 @@ class RegexTests(unittest.TestCase):
         '_1a._2b._3b',
         'a.b.c.',
         'a1a.b2b.c2c.',
-        'a1a_.b2_b.c_2c.'
-    )
-    def test_json_formatter_dotted_key_regex_match(self, key):
-        self.assertIsNotNone(dotted_key_regex.match(key))
-
-    @params(
+        'a1a_.b2_b.c_2c.',
         'my key.',
         '1.2',
         'This is a text. It contains dot.',
@@ -34,7 +41,9 @@ class RegexTests(unittest.TestCase):
         'my.key-test',
         '1',
         '1.test',
-        '_1.1test'
+        '_1.1test',
+        '%()s',
+        'asd %()s asdf'
     )
-    def test_json_formatter_dotted_key_regex_no_match(self, key):
-        self.assertIsNone(dotted_key_regex.match(key))
+    def test_json_formatter_enhanced_percent_style_regex_not_match(self, value):
+        self.assertIsNone(EnhancedPercentStyle.validation_pattern.search(value))


### PR DESCRIPTION
The string constant in the JSON Formatter caused troubled when the user
wanted to have an extra parameter in his log only if the extra was present.
In the case were the extra parameter was not present, the formatter could not
differentiate if it was a missing extra parameter or a string constant and
was therefore added as constant. This could cause some types inconsistency in
the json log output, for example if some log would add an extra as dictionary,
when this dict would be missing in the log record the log output would not be
a dictionary but a string constant.

Here below an example of config that caused this issue:

```python
# Format used in JSONFormater
fmt={"message", "message", "request": {"headers": "flask_request_headers"}}

logger.info('Message without Flask context')
> {"message": "Message without Flask context", "request": {"headers": "flask_request_headers"}}

logger.info('Message with Flask context')
> {"message": "Message with Flask context", "request": {"headers": {"Host": "www.example.com", ...}}}
```

To avoid such issue we simply removed the string constant feature. This can
still be achieved using the ConstAttribute filter.

Now if an attribute is missing from the log record, it will raise a ValueError
like the standard python formatter. You can avoid such exception by using the
`ignore_missing=True` configuration, in this case the default value will be
an empty string `''`.

Empty string might still cause some type inconsistency, so you can either use `remove_empty=True` to totally remove empty keys from the JSON log, or use the trailing dot notation to change the default value: 

- single trailing dot: `{}`
- double trailing dot: `[]`