### PR TITLE
Fixed auto-publish - #patch

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -15,9 +15,9 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          fetch-depth: '10'
+          fetch-depth: 0
 
       - name: Build and Publish Package on PyPI
         run: make publish

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ DEV_REQUIREMENTS_TIMESTAMP = $(VENV)/.dev-requirements.timestamp
 
 # general targets timestamps
 TIMESTAMPS = .timestamps
-PREP_PACKAGING_TIMESTAMP = $(TIMESTAMPS)/.prep-packaging.timestamp
 
 # Find all python files that are not inside a hidden directory (directory starting with .)
 PYTHON_FILES := $(shell find ./* -type d \( -path ./build -o -path ./dist \) -prune -false -o -type f -name "*.py" -print)
@@ -107,7 +106,7 @@ test: $(DEV_REQUIREMENTS_TIMESTAMP)
 # Packaging target
 
 .PHONY: package
-package: $(PREP_PACKAGING_TIMESTAMP)
+package: $(DEV_REQUIREMENTS_TIMESTAMP)
 	$(PYTHON) -m build
 
 
@@ -156,11 +155,6 @@ $(VENV_TIMESTAMP):
 $(DEV_REQUIREMENTS_TIMESTAMP): $(VENV_TIMESTAMP) $(DEV_REQUIREMENTS)
 	$(PIP) install -r $(DEV_REQUIREMENTS)
 	@touch $(DEV_REQUIREMENTS_TIMESTAMP)
-
-
-$(PREP_PACKAGING_TIMESTAMP): $(TIMESTAMPS)
-	python3 -m pip install --user --upgrade setuptools wheel twine
-	@touch $(PREP_PACKAGING_TIMESTAMP)
 
 
 publish-check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "logging-utilities"
 requires-python = ">=3.0"
 description = """\
-A collection of useful logging formatters and filters.
+A collection of useful logging formatters and filters.\
 Logging Context, JSON Formatter, Extra Formatter, ISO Time Filter, Flask Filter, Django Filter, ...\
 """
 readme = "README.md"


### PR DESCRIPTION
In order to allow the CI (github action) to build the package and to publish it,
the actions/checkout needs to fetch everything inclusive git tags, therefore
we set the `fetch-depth` to `0`.

Did some cleanup in makefile and also avoid a multiline warning due to pyproject.toml