### PR TITLE
Improved CI, publish scripts and docu - #patch

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Build and Publish Package on PyPI
         run: make publish
         env:
-          PYPI_USER: ${{ secrets.PYPI_USER }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,6 @@ DEV_REQUIREMENTS = $(CURRENT_DIR)/dev_requirements.txt
 TEST_REPORT_DIR ?= $(CURRENT_DIR)/tests/report
 TEST_REPORT_FILE ?= nose2-junit.xml
 
-# PyPI credentials
-PYPI_USER ?=
-PYPI_PASSWORD ?=
-
 # venv targets timestamps
 VENV_TIMESTAMP = $(VENV)/.timestamp
 DEV_REQUIREMENTS_TIMESTAMP = $(VENV)/.dev-requirements.timestamp
@@ -113,7 +109,7 @@ package: $(DEV_REQUIREMENTS_TIMESTAMP)
 .PHONY: publish
 publish: clean-all publish-check setup package
 	@echo "Upload package version=$(PACKAGE_VERSION)"
-	$(PYTHON) -m twine upload -u $(PYPI_USER) -p $(PYPI_PASSWORD) dist/*
+	$(PYTHON) -m twine upload dist/*
 
 
 # Clean targets

--- a/README.md
+++ b/README.md
@@ -78,22 +78,12 @@ pip install logging-utilities
 
 ## Release and Publish
 
-Only owners are allowed to publish a new version to PyPI. To publish a new version follow the procedure below:
+New release and publish on PyPI is done automatically upon PR merge into `master` branch. For bug fixes and small new features,
+PR can be directly open on `master`. Then the PR title define the version bump as follow:
 
-1. Increase the `VERSION` in `logging_utilities/__init__.py`
-    - Major version for outbreak changes in the user interface (no backward compatibility)
-    - Minor version for new features
-    - Patch version for bug fixes
-    - For alpha version append `alpha1` to `VERSION`
-1. Commit and push the changes to `develop` branch
-1. Merge `develop` to  `master`
-1. From `master` branch enter
-
-    ```shell
-    summon -p gopass --up make publish
-    ```
-
-**NOTE**: this requires to have `summon`, `gopass` and the correct `secrets.yml` file in a parent folder.
+- PR title and/or commit message contains `#major` => major version is bumped
+- PR title and/or commit message contains `#patch` or head branch name starts with `bug-|hotfix-|bugfix-` => patch version is bumped
+- Otherwise by default the minor version is bumped
 
 ## Contribution
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -24,8 +24,6 @@ phases:
       - make ci-check-format
       - echo "=== Linting ====================================================="
       - make lint
-  build:
-    commands:
       - echo "================================================================="
       - echo "Setting up dev mode with python version $(python --version)..."
       - pip install --upgrade pip
@@ -47,3 +45,7 @@ phases:
       - python3.9 -m pip install -e .
       - echo "Running nose tests..."
       - python3.9 -m nose2 -v -s tests/
+  build:
+    commands:
+      - echo "=== Build package ==============================================="
+      - make package


### PR DESCRIPTION
- Uses the twine env vars to avoid putting credentials on command line
- updated docu
- Added build package to CI