### PR TITLE
BGDIINF_SB-4114: Moved pypi publish workflow to codebuild - #patch

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -10,17 +10,3 @@ jobs:
   release:
     uses: geoadmin/.github/.github/workflows/semver-release.yml@master
 
-  publish:
-    needs: release
-    if: ${{ github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Build and Publish Package on PyPI
-        run: make publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ PR can be directly open on `master`. Then the PR title define the version bump a
 - PR title and/or commit message contains `#patch` or head branch name starts with `bug-|hotfix-|bugfix-` => patch version is bumped
 - Otherwise by default the minor version is bumped
 
-Note that publish is done by `.github/workflow/semver.yml` and not by codebuild.
-
 ## Contribution
 
 Every contribution to this library is welcome ! So if you find a bug or want to add a new feature everyone is welcome to open an [issue](https://github.com/geoadmin/lib-py-logging-utilities/issues) or created a [Pull Request](https://github.com/geoadmin/lib-py-logging-utilities/pulls).


### PR DESCRIPTION
Due to changes in pypi authentication, the pypi publish workflow is now handled by codebuild