### PR TITLE
Support py3.12: Add taskName to the list of default log attrs

### DIFF
--- a/logging_utilities/formatters/__init__.py
+++ b/logging_utilities/formatters/__init__.py
@@ -20,5 +20,6 @@ RECORD_DFT_ATTR = {
     'stack_info',
     'msg',
     'args',
-    'message'
+    'message',
+    'taskName'
 }


### PR DESCRIPTION
In Python 3.12 the attribute `taskName` was introduced. This broke our unit tests, as they didn't expect this attribute to be there and added them to the list of extras