### PR TITLE
GPS-646: otel logger - #minor

### DIFF
--- a/logging_utilities/formatters/otel_formatter.py
+++ b/logging_utilities/formatters/otel_formatter.py
@@ -1,0 +1,103 @@
+import json
+
+from logging_utilities.formatters.json_formatter import JsonFormatter
+from logging_utilities.formatters.json_formatter import deep_merge
+from logging_utilities.formatters.json_formatter import dictionary
+
+# OTel log severity number mapping
+# https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+OTEL_SEVERITY_MAP = {
+    "DEBUG": 5,
+    "INFO": 9,
+    "WARNING": 13,
+    "ERROR": 17,
+    "CRITICAL": 21,
+}
+
+DEFAULT_OTEL_FORMAT = dictionary([
+    # OTEL semantic conventions (semconv) v1.40.0
+    # https://opentelemetry.io/docs/specs/semconv/
+    ("code.file.path", "pathname"),
+    ("code.line.number", "lineno"),
+    ("code.function.name", "funcName"),
+    ("process.pid", "process"),
+    ("thread.id", "thread"),
+    # Custom attributes fields - not following OTEL semantic conventions
+    ("event.category", "web"),
+    ("event.duration", "duration"),
+    ("event.kind", "event"),
+    ("log.logger", "name"),
+    ("service.type", "service_type"),
+    # OTEL Log fields
+    # https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition
+    ("body.string", "message"),
+    ("otelSpanID", "otelSpanID"),
+    ("otelTraceID", "otelTraceID"),
+    ("severity_text", "levelname"),
+    ("Timestamp", "utc_isotime"),
+])
+
+
+class OtelFormatter(JsonFormatter):
+    """Logging formatter that emits JSON conforming to the OpenTelemetry log data model.
+
+    Extends JsonFormatter with OTel-specific fields: Timestamp in nanoseconds,
+    SeverityNumber mapping, TraceId/SpanId injection, and a Resource block.
+    """
+
+    def __init__(
+        self,
+        fmt=None,
+        fmtFile=None,
+        datefmt=None,
+        style="%",
+        add_always_extra=False,
+        filter_attributes=None,
+        remove_empty=True,
+        ignore_missing=True,
+        service_name=None,
+        **kwargs,
+    ):
+        """OTel Formatter constructor
+
+        Args:
+            service_name: (string)
+                Value for the Resource 'service.name' attribute. If None, falls back to
+                whatever the fmt provides.
+            All other args are forwarded to JsonFormatter.
+        """
+        if filter_attributes is None:
+            filter_attributes = ["utc_isotime", "service_type"]
+
+        # Merge order (later wins): DEFAULT_OTEL_FORMAT < fmtFile < fmt
+        if fmtFile is not None:
+            with open(fmtFile, "r", encoding="utf-8") as f:
+                fmt_from_file = json.load(f, object_pairs_hook=dictionary)
+            base = deep_merge(DEFAULT_OTEL_FORMAT, fmt_from_file)
+        else:
+            base = DEFAULT_OTEL_FORMAT
+
+        fmt = deep_merge(base, fmt) if fmt is not None else base
+
+        super().__init__(
+            fmt=fmt,
+            fmtFile=None,
+            datefmt=datefmt,
+            style=style,
+            add_always_extra=add_always_extra,
+            filter_attributes=filter_attributes,
+            remove_empty=remove_empty,
+            ignore_missing=ignore_missing,
+            **kwargs,
+        )
+
+        self.service_name = service_name
+
+    def format(self, record):
+        # Enrich the record with computed OTel fields before JsonFormatter processes it
+        if self.service_name is not None:
+            record.service_name = self.service_name
+
+        json_str = super().format(record)
+
+        return json_str

--- a/tests/test_otel_formatter.py
+++ b/tests/test_otel_formatter.py
@@ -1,0 +1,162 @@
+import json
+import logging
+import sys
+import tempfile
+import unittest
+from collections import OrderedDict
+
+from logging_utilities.formatters.otel_formatter import OtelFormatter
+
+if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
+    dictionary = dict
+else:
+    dictionary = OrderedDict
+
+
+def _make_logger(name, formatter):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    for handler in logger.handlers:
+        handler.setFormatter(formatter)
+    return logger
+
+
+class TestOtelFormatterDefaults(unittest.TestCase):
+
+    def test_default_keys_present(self):
+        with self.assertLogs('otel.defaults', level=logging.DEBUG) as ctx:
+            logger = _make_logger('otel.defaults', OtelFormatter(ignore_missing=True))
+            logger.info('hello')
+
+        msg = json.loads(ctx.output[0])
+        for key in ('severity_text', 'body.string', 'log.logger'):
+            self.assertIn(key, msg, f'expected key {key!r} in output')
+
+    def test_severity_text_value(self):
+        with self.assertLogs('otel.severity', level=logging.DEBUG) as ctx:
+            logger = _make_logger('otel.severity', OtelFormatter(ignore_missing=True))
+            logger.warning('warn msg')
+
+        msg = json.loads(ctx.output[0])
+        self.assertEqual(msg['severity_text'], 'WARNING')
+
+    def test_body_string_value(self):
+        with self.assertLogs('otel.body', level=logging.DEBUG) as ctx:
+            logger = _make_logger('otel.body', OtelFormatter(ignore_missing=True))
+            logger.info('the body')
+
+        msg = json.loads(ctx.output[0])
+        self.assertEqual(msg['body.string'], 'the body')
+
+    def test_remove_empty_default(self):
+        # remove_empty=True by default: keys with empty values should be absent
+        with self.assertLogs('otel.remove_empty', level=logging.DEBUG) as ctx:
+            logger = _make_logger('otel.remove_empty', OtelFormatter())
+            logger.info('msg')
+
+        msg = json.loads(ctx.output[0])
+        # duration and otelSpanID/otelTraceID are absent when not set
+        self.assertNotIn('event.duration', msg)
+        self.assertNotIn('otelSpanID', msg)
+        self.assertNotIn('otelTraceID', msg)
+
+
+class TestOtelFormatterFmtMerge(unittest.TestCase):
+
+    def test_fmt_overrides_default(self):
+        custom_fmt = dictionary([('body.string', 'message'), ('custom_key', 'levelname')])
+        with self.assertLogs('otel.merge', level=logging.DEBUG) as ctx:
+            logger = _make_logger('otel.merge', OtelFormatter(fmt=custom_fmt, ignore_missing=True))
+            logger.error('err')
+
+        msg = json.loads(ctx.output[0])
+        # custom key added
+        self.assertEqual(msg['custom_key'], 'ERROR')
+        # default key still present
+        self.assertIn('severity_text', msg)
+
+    def test_fmt_overrides_default_value(self):
+        # Override an existing default key's mapping
+        custom_fmt = dictionary([('severity_text', 'name')])
+        with self.assertLogs('otel.override', level=logging.DEBUG) as ctx:
+            logger = _make_logger(
+                'otel.override', OtelFormatter(fmt=custom_fmt, ignore_missing=True)
+            )
+            logger.info('msg')
+
+        msg = json.loads(ctx.output[0])
+        self.assertEqual(msg['severity_text'], 'otel.override')
+
+    def test_fmt_file_merges_with_default(self):
+        file_fmt = {'extra_from_file': 'levelname', 'severity_text': 'name'}
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False, encoding='utf-8'
+        ) as f:
+            json.dump(file_fmt, f)
+            tmp_path = f.name
+
+        with self.assertLogs('otel.fmtfile', level=logging.DEBUG) as ctx:
+            logger = _make_logger(
+                'otel.fmtfile', OtelFormatter(fmtFile=tmp_path, ignore_missing=True)
+            )
+            logger.info('msg')
+
+        msg = json.loads(ctx.output[0])
+        # fmtFile key present
+        self.assertIn('extra_from_file', msg)
+        # fmtFile overrides default
+        self.assertEqual(msg['severity_text'], 'otel.fmtfile')
+        # default keys still present
+        self.assertIn('body.string', msg)
+
+    def test_fmt_wins_over_fmt_file(self):
+        file_fmt = {'severity_text': 'name'}
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False, encoding='utf-8'
+        ) as f:
+            json.dump(file_fmt, f)
+            tmp_path = f.name
+
+        # fmt overrides fmtFile for the same key
+        custom_fmt = dictionary([('severity_text', 'levelname')])
+        with self.assertLogs('otel.fmtfile_vs_fmt', level=logging.DEBUG) as ctx:
+            logger = _make_logger(
+                'otel.fmtfile_vs_fmt',
+                OtelFormatter(fmt=custom_fmt, fmtFile=tmp_path, ignore_missing=True),
+            )
+            logger.warning('msg')
+
+        msg = json.loads(ctx.output[0])
+        self.assertEqual(msg['severity_text'], 'WARNING')
+
+
+class TestOtelFormatterServiceName(unittest.TestCase):
+
+    def test_service_name_injected(self):
+        with self.assertLogs('otel.svcname', level=logging.DEBUG) as ctx:
+            fmt = dictionary([('service.name', 'service_name')])
+            logger = _make_logger(
+                'otel.svcname',
+                OtelFormatter(fmt=fmt, service_name='my-service', ignore_missing=True),
+            )
+            logger.info('msg')
+
+        msg = json.loads(ctx.output[0])
+        self.assertEqual(msg['service.name'], 'my-service')
+
+    def test_no_service_name_when_not_set(self):
+        with self.assertLogs('otel.nosvcname', level=logging.DEBUG) as ctx:
+            fmt = dictionary([('service.name', 'service_name')])
+            logger = _make_logger(
+                'otel.nosvcname',
+                OtelFormatter(fmt=fmt, ignore_missing=True),
+            )
+            logger.info('msg')
+
+        msg = json.loads(ctx.output[0])
+        # service_name not on record and ignore_missing=True → absent (remove_empty=True)
+        self.assertNotIn('service.name', msg)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Sister PR for https://github.com/swissgeo/service-oa-records/pull/14

Allows to have much less definitions in logging.conf
Mainly allows you to replace the whole `formatters` section with one line.

You can still overwrite / override rules there.

Out of the box, it will format all stdout logs correctly for OTEL/ElasticSearch:

<img width="941" height="162" alt="image" src="https://github.com/user-attachments/assets/4faee945-6987-44b0-a8c5-9d9c1f9da38a" />
